### PR TITLE
Await track() to successfully run serverless function

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -4,7 +4,7 @@ import { analytics } from './utils/analytics'
 export default async function middleware(req: NextRequest) {
   if (req.nextUrl.pathname === '/') {
     try {
-      analytics.track('pageview', {
+      await analytics.track('pageview', {
         page: '/',
         country: req.geo?.country,
       })


### PR DESCRIPTION
This does not work with vercel deployments unless you `await` the function call in the middleware. Some people are having trouble with this issue, with it only working locally and not in production on vercel. This is the solution.

See ISSUE https://github.com/joschan21/next-analytics/issues/1

I was unable to get the db posts to upstash in production until adding this await call.